### PR TITLE
New upstream release 1.7.0-2

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,27 @@
+tsung (1.7.0-2) unstable; urgency=medium
+
+  * debian/patches:
+    - 01_correct_share_path.diff: Fix relative path to `/usr/share/tsung`.
+      (Closes: #873678) (LP: #1634143)
+    - 02_tsplot_manpage_typo.diff: Fix minor typos.
+
+ -- Ignace Mouzannar <mouzannar@gmail.com>  Thu, 16 Nov 2017 00:20:00 -0500
+
+tsung (1.7.0-1) unstable; urgency=medium
+
+  * New upstream release.
+  * debian/control:
+    - Bumped Standards-Version to 4.1.1.
+    - Update python-sphinx dependency to python3-sphinx.
+    - Remove ${erlang-abi:Depends} unused dependency, covered 
+      by ${erlang:Depends}
+  * debian/tsung.lintian-overrides:
+    - Added file to ignore some expected lintian warnings.
+  * debian/copyright:
+    - Add mention to new file src/tsung/ts_server_websocket_ssl.erl
+
+ -- Ignace Mouzannar <mouzannar@gmail.com>  Wed, 15 Nov 2017 23:06:34 -0500
+
 tsung (1.6.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/control
+++ b/control
@@ -10,16 +10,15 @@ Build-Depends: autotools-dev,
  erlang-src,
  python (>= 2.6.6-3~),
  dh-python,
- python-sphinx
+ python3-sphinx
 Homepage: http://tsung.erlang-projects.org/
-Standards-Version: 3.9.8
+Standards-Version: 4.1.1
 
 Package: tsung
 Architecture: any
 Depends: gnuplot,
  libtemplate-perl,
  python-matplotlib,
- ${erlang-abi:Depends},
  ${erlang:Depends},
  ${misc:Depends},
  ${python:Depends},

--- a/copyright
+++ b/copyright
@@ -177,6 +177,12 @@ Copyright:
     2013, Matthew Wood <hellomatty@gmail.com>
 License: MIT
 
+Files:
+    src/tsung/ts_server_websocket_ssl.erl
+Copyright:
+    Eric Cestari <ecestari@mac.com>
+License: GPL-2+
+
 License: GPL-2+
  This program is free software; you can redistribute it
  and/or modify it under the terms of the GNU General Public

--- a/patches/01_correct_share_path.diff
+++ b/patches/01_correct_share_path.diff
@@ -1,0 +1,17 @@
+Description:
+  - Fix relative path to `/usr/share/tsung`
+Author: Ignace Mouzannar <mouzannar@gmail.com>
+Last-Update: 2017-11-15
+
+Index: tsung-1.7.0/src/tsung_controller/ts_controller_sup.erl
+===================================================================
+--- tsung-1.7.0.orig/src/tsung_controller/ts_controller_sup.erl
++++ tsung-1.7.0/src/tsung_controller/ts_controller_sup.erl
+@@ -144,6 +144,6 @@ start_inets(LogDir,Redirect) ->
+ template_path() ->
+     case ?config(template_path) of
+         beam_relative ->
+-            filename:join(filename:dirname(code:which(tsung_controller)),"../../../../share/tsung/templates");
++            filename:join(filename:dirname(code:which(tsung_controller)),"/usr/share/tsung/templates");
+         Other -> Other
+     end.

--- a/patches/02_tsplot_manpage_typo.diff
+++ b/patches/02_tsplot_manpage_typo.diff
@@ -1,0 +1,27 @@
+Description:
+  - Fix minor typos
+Author: Ignace Mouzannar <mouzannar@gmail.com>
+Last-Update: 2017-11-15
+
+Index: tsung-1.7.0/man/tsplot.1
+===================================================================
+--- tsung-1.7.0.orig/man/tsplot.1
++++ tsung-1.7.0/man/tsplot.1
+@@ -11,7 +11,7 @@ Tsung comes with a plotting tool using
+ \fBgnuplot\fR, producing some graphs from the
+ \fItsung.log\fR file data.
+ \fBtsplot\fR is able to plot data from several
+-\fItsung.log\fR files onto the same charts serie,
++\fItsung.log\fR files onto the same charts series,
+ for further comparison and analyze.
+ .SH "OPTIONS"
+ .PP
+@@ -172,7 +172,7 @@ on command line.
+ Each plot on a chart has a legend entry, you configure
+ here the meaning of the plot (say 'concurrent users') and
+ \fBtsplot\fR will add it the name of the data
+-serie being plotted (say 'scenario x'). You'd obtain this
++series being plotted (say 'scenario x'). You'd obtain this
+ legend: 'concurrent users scenario x'.
+ .TP
+ \fBylabel\fR

--- a/patches/series
+++ b/patches/series
@@ -1,0 +1,2 @@
+02_tsplot_manpage_typo.diff
+01_correct_share_path.diff

--- a/source/lintian-overrides
+++ b/source/lintian-overrides
@@ -1,0 +1,1 @@
+tsung source: debian-watch-uses-insecure-uri http://tsung.erlang-projects.org/dist/tsung-(.*)\.tar\.gz


### PR DESCRIPTION
* debian/patches:
  - 01_correct_share_path.diff: Fix relative path to `/usr/share/tsung`.
    (Closes: #873678) (LP: #1634143)
  - 02_tsplot_manpage_typo.diff: Fix minor typos.
* New upstream release.
* debian/control:
  - Bumped Standards-Version to 4.1.1.
  - Update python-sphinx dependency to python3-sphinx.
  - Remove ${erlang-abi:Depends} unused dependency, covered
    by ${erlang:Depends}
* debian/tsung.lintian-overrides:
  - Added file to ignore some expected lintian warnings.
* debian/copyright:
  - Add mention to new file src/tsung/ts_server_websocket_ssl.erl