### PR TITLE
v1.7.0-3

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+tsung (1.7.0-3) unstable; urgency=medium
+
+  * debian/patches:
+    - 03_correct_lib_path.diff: Fix relative path to 
+      `/usr/lib/$(DEB_HOST_MULTIARCH)/tsung/bin`
+      (Closes: #873678) (LP: #1634143)
+
+ -- Ignace Mouzannar <mouzannar@gmail.com>  Thu, 16 Nov 2017 00:55:06 -0500
+
 tsung (1.7.0-2) unstable; urgency=medium
 
   * debian/patches:

--- a/patches/03_correct_lib_path.diff
+++ b/patches/03_correct_lib_path.diff
@@ -1,0 +1,18 @@
+Description:
+  - Fix relative path to `/usr/lib/$(DEB_HOST_MULTIARCH)/tsung/bin`
+Author: Ignace Mouzannar <mouzannar@gmail.com>
+Last-Update: 2017-11-15
+
+Index: tsung-1.7.0/src/tsung_controller/ts_web.erl
+===================================================================
+--- tsung-1.7.0.orig/src/tsung_controller/ts_web.erl
++++ tsung-1.7.0/src/tsung_controller/ts_web.erl
+@@ -99,7 +99,7 @@ error(SessionID, _Env, _Input, Msg) ->
+ 
+ script_paths()->
+     {ok,Path} = application:get_env(tsung_controller,log_dir_real),
+-    UserPath = filename:join(Path,"../../../lib/tsung/bin"),
++    UserPath = filename:join(Path,"../../../tsung/bin"),
+     ts_utils:join(":",[UserPath,"/usr/lib64/tsung/bin/","/usr/lib/tsung/bin","/usr/local/lib/tsung/bin"]).
+ 
+ update_reports() ->

--- a/patches/series
+++ b/patches/series
@@ -1,2 +1,3 @@
+03_correct_lib_path.diff
 02_tsplot_manpage_typo.diff
 01_correct_share_path.diff


### PR DESCRIPTION
* debian/patches:
  - 03_correct_lib_path.diff: Fix relative path to
    `/usr/lib/$(DEB_HOST_MULTIARCH)/tsung/bin`
    (Closes: #873678) (LP: #1634143)